### PR TITLE
changes for docker-compose config for frontend

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -8,7 +8,7 @@ This application is dockerized so ideally you only need `docker` and `docker-com
 To start the server (api) locally, just run:
 
 ```bash
-docker-compose up server-local
+docker-compose up server
 ```
 
 To run the unit tests (not yet setup), just run:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 version: "3.7"
 services:
-  server-local:
+  server:
     build:
       context: .
     image: ovloop-api
@@ -14,6 +14,7 @@ services:
     depends_on:
       - localstack
       - mongo
+      - front
     environment:
       NODE_ENV: local
       REGION_SNS: us-east-2
@@ -21,6 +22,15 @@ services:
       AWS_SECRET_ACCESS_KEY: anysecret
     tty: true
     entrypoint: ["npm", "run", "local"]
+  front:
+    image: ovloop-front
+    container_name: ovloop-front_container
+    ports:
+      - "7777:7777"
+    environment: 
+      NODE_ENV: local
+      API_HOST: server
+      API_PORT: 8080
   localstack:
     image: localstack/localstack
     container_name: ovloop-api_localstack


### PR DESCRIPTION
Changes on docker-compose to add front service that will build/run frontend project.
To be able to run it, must be build frontend before.

The env variables to be used on frontend project must be define in this project docker-compose.