### PR TITLE
remove front as dependency when running backend, still can be started…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,6 @@ services:
     depends_on:
       - localstack
       - mongo
-      - front
     environment:
       NODE_ENV: local
       REGION_SNS: us-east-2


### PR DESCRIPTION
… from there but running the docker-compose up front apart